### PR TITLE
feat(llm): free-form suggestions, LLM tags, configurable prompt template + versioned cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ python import.py --smart \
   --llm-provider openai \
   --llm-model gpt-4o-mini \
   --llm-timeout 30 \
-  --llm-concurrency 4
+  --llm-concurrency 4 \
+  --clear-llm-cache
 ```
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Successfully implemented enhanced processing with:
 ### New: LLM-based Note Categorization (Phase 3)
 - Assign a single primary category to each note using a configurable Large Language Model (LLM)
 - Category is stored in metadata as `category`, can be propagated as a tag, and preferred by Folder Organizer
-- Supports providers: openai, anthropic, ollama (OpenAI-compatible), vertex, groq
-- Caching, confidence thresholds, suggestions policy, and token controls (head/tail sampling)
+- Powered by LiteLLM: supports providers like openai, anthropic, ollama (OpenAI-compatible), vertex, groq
+- Caching, confidence thresholds, suggestions policy, lightweight progress logs, and token controls (head/tail sampling)
 - See docs/llm-categorization.md and the full sample config at config/sample_config_full.yaml
 
 ## Usage
@@ -68,8 +68,10 @@ python import.py --smart \
 ```
 
 Notes:
-- Providers: openai | anthropic | ollama | vertex | groq
-- API keys via env vars configured in your YAML (see config/sample_config_full.yaml). Do not store secrets in files.
+- Providers: openai | anthropic | ollama | vertex | groq (via LiteLLM)
+- Models can be specified as provider-prefixed (e.g., `openai/gpt-4o-mini`, `anthropic/claude-3-haiku`) or as a plain model name with `--llm-provider` determining the prefix.
+- API keys: use standard env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, etc.) or map your custom names via `llm_api_keys` in YAML. Do not store secrets in files.
+- `--llm-base-url` maps to LiteLLM `api_base` (useful for OpenAI-compatible local gateways like Ollama).
 - Results are cached to .cache/llm_category.jsonl when enabled. .cache/ is git-ignored.
 
 ### Basic Usage

--- a/config/prompts/default_classifier_prompt.txt
+++ b/config/prompts/default_classifier_prompt.txt
@@ -1,0 +1,31 @@
+LLM Prompt Version: {{llm_prompt_version}}
+
+You are a JSON-only classifier. Read the note text and respond with a single JSON object. Do not include any extra text.
+
+Allowed primary category slugs (choose exactly one or 'other' for primary):
+{{allowed_slugs}}
+
+Category descriptions:
+{{descriptions}}
+
+Instructions:
+- Choose primary category_slug only from the allowed list or 'other'. Never invent a new slug for the primary category.
+- Provide confidence between 0 and 1 (float). Aim to reflect your certainty.
+- Provide a brief reasons string.
+- Provide suggestions: a single array of alternative categories. These MAY be free-form and are NOT limited to the allowed list. Limit to at most {{suggestions_count}} suggestions. Free-form suggestions allowed: {{allow_freeform_suggestions}}.
+- Tags: If {{suggest_tags}} is true, include an array of topical tags (not prefixed with '#') that describe the note. Limit to at most {{tags_max_count}} items. Tags may be free-form.
+- Return only valid JSON; no markdown.
+
+Respond as JSON with this schema:
+{
+  "category_slug": "one-of-allowed-or-other-or-null",
+  "confidence": 0.0,
+  "reasons": "short explanation",
+  "suggestions": ["free form", "or from allowed", "..."],
+  "tags": ["topic-1", "topic 2", "etc"]
+}
+
+Minimum confidence threshold for assignment: {{min_confidence}}
+
+Note text (truncated):
+{{text}}

--- a/config/sample_config_full.yaml
+++ b/config/sample_config_full.yaml
@@ -23,7 +23,7 @@ enable_note_splitting: false
 # This category may be propagated to tags and used to drive folder mapping.
 # See docs/llm-categorization.md for details.
 
-enable_llm_categorization: true
+enable_llm_categorization: false
 
 # Provider to use: openai | anthropic | ollama | vertex | groq
 llm_provider: openai

--- a/config/sample_config_full.yaml
+++ b/config/sample_config_full.yaml
@@ -111,6 +111,9 @@ categories:
   - name: Anime
     slug: anime
     description: "Japanese anime tv shows and movies"
+  - name: Health
+    slug: health
+    description: "Medical health, body measurements, exercise, workouts"
   - name: Other
     slug: other
     description: "Fallback category for low-confidence or uncategorized notes."
@@ -186,4 +189,3 @@ split_notes_patterns: []
 split_enabled_tags:
   - cocktails
   - recipes
-  - drinks

--- a/config/sample_config_full.yaml
+++ b/config/sample_config_full.yaml
@@ -23,7 +23,7 @@ enable_note_splitting: true
 # This category may be propagated to tags and used to drive folder mapping.
 # See docs/llm-categorization.md for details.
 
-enable_llm_categorization: true
+enable_llm_categorization: false
 
 # Provider to use: openai | anthropic | ollama | vertex | groq
 llm_provider: openai

--- a/config/sample_config_full.yaml
+++ b/config/sample_config_full.yaml
@@ -14,7 +14,7 @@ enable_content_transformation: true
 # Phase 3 Feature Toggles
 # -----------------------------
 # Enable advanced features like note splitting
-enable_note_splitting: false
+enable_note_splitting: true
 
 # -----------------------------
 # LLM-based Categorization
@@ -23,7 +23,7 @@ enable_note_splitting: false
 # This category may be propagated to tags and used to drive folder mapping.
 # See docs/llm-categorization.md for details.
 
-enable_llm_categorization: false
+enable_llm_categorization: true
 
 # Provider to use: openai | anthropic | ollama | vertex | groq
 llm_provider: openai
@@ -34,7 +34,7 @@ llm_provider: openai
 # - Groq: mixtral-8x7b, llama3-* (check Groq docs)
 # - Vertex: see Vertex AI model names
 # - Ollama: name of local model served via OpenAI-compatible endpoint
-llm_model: gpt-4o-mini
+llm_model: gpt-5-mini
 
 # Provider -> Environment Variable name containing the API key.
 # Do NOT store secrets in files. Ensure your environment exports these variables before running.
@@ -66,11 +66,20 @@ llm_tail_chars: 500            # And the end; helps short notes and summaries
 # Policy when the model is uncertain (below confidence threshold):
 # - other: assign the 'other' category
 # - suggest: leave category unset, but attach _category_suggestions with up to suggestions_count entries
-undecided_policy: other
+undecided_policy: suggest
 suggestions_count: 3
 
 # If true, ensure the chosen category slug is present in the note's tags
 propagate_category_tag: true
+
+# LLM Prompt Template and Suggestions
+# If provided, the classifier will load and render this template with placeholders.
+llm_prompt_template_path: null  # e.g., config/prompts/default_classifier_prompt.txt
+llm_prompt_version: v1          # Changing this invalidates cache keys
+llm_allow_freeform_suggestions: true   # Allow suggestions beyond configured slugs
+llm_suggest_tags: true                  # Ask LLM to return tags for the note
+llm_tags_max_count: 5                   # Cap on number of LLM tags
+llm_tags_min_count: 0                   # Minimum desired (informational)
 
 # Complete set of available categories for the classifier.
 # Include a fallback 'other' slug.
@@ -96,6 +105,12 @@ categories:
   - name: Role-playing games
     slug: role-playing-games
     description: "Tabletop RPGs, characters, campaigns, rules."
+  - name: Movies
+    slug: movies
+    description: "Lists of movies, titles of movies"
+  - name: Anime
+    slug: anime
+    description: "Japanese anime tv shows and movies"
   - name: Other
     slug: other
     description: "Fallback category for low-confidence or uncategorized notes."

--- a/docs/llm-categorization.md
+++ b/docs/llm-categorization.md
@@ -51,6 +51,7 @@ When enable_llm_categorization=true, the processors run in this order:
 - Uses provider-specific client (OpenAI first) to classify.
 - Confidence threshold (llm_min_confidence) controls assignment vs undecided.
 - Cache (JSONL) is used to avoid repeated calls when enabled.
+- You can clear the cache at startup using the `--clear-llm-cache` CLI flag.
 - Diagnostics stored in metadata (prefixed with _category_*) are for internal use.
 
 ## FolderOrganizer integration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==6.0.2
 python-dateutil==2.9.0.post0
+litellm>=1.42.0

--- a/scripts/generate_category_report.py
+++ b/scripts/generate_category_report.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Generate an aggregate report of LLM-suggested categories and tags from the
+.cache/llm_category.jsonl file produced by the importer.
+
+Sections:
+1) Suggested categories (distribution)
+2) Tags by suggested category
+3) Suggested tags with their category distribution
+
+Usage:
+  python scripts/generate_category_report.py \
+    --input .cache/llm_category.jsonl \
+    --output category_report.md
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Tuple, Dict, Any
+
+
+def norm_cat(s: str) -> str:
+    return s.strip().lower()
+
+
+def norm_tag(s: str) -> str:
+    return s.strip().lower()
+
+
+def sort_items(counter: Dict[str, int]):
+    return sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
+
+
+def iter_jsonl(path: Path) -> Iterable[Tuple[int, Dict[str, Any]]]:
+    with path.open('r', encoding='utf-8') as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield i, json.loads(line)
+            except Exception:
+                # skip malformed lines silently (or print to stderr if preferred)
+                continue
+
+
+def generate_report(input_path: Path, output_path: Path) -> None:
+    cat_counts: Counter = Counter()
+    tags_by_cat: Dict[str, Counter] = defaultdict(Counter)
+    cat_by_tag: Dict[str, Counter] = defaultdict(Counter)
+
+    total_processed = 0
+
+    for idx, rec in iter_jsonl(input_path):
+        res = rec.get('result') or {}
+        cat_raw = res.get('category_slug')
+        # Treat missing/None as 'other' for aggregation
+        cat = norm_cat(cat_raw) if isinstance(cat_raw, str) and cat_raw.strip() else 'other'
+
+        tags = res.get('tags') or []
+        if not isinstance(tags, (list, tuple)):
+            # still count the category occurrence
+            cat_counts[cat] += 1
+            total_processed += 1
+            continue
+
+        tags_norm = [norm_tag(t) for t in tags if isinstance(t, str) and t.strip()]
+
+        # Count the record itself
+        cat_counts[cat] += 1
+        total_processed += 1
+
+        # De-duplicate tags within a single record before counting
+        for t in set(tags_norm):
+            tags_by_cat[cat][t] += 1
+            cat_by_tag[t][cat] += 1
+
+    if total_processed == 0:
+        raise SystemExit("No valid records parsed from input JSONL.")
+
+    ts = datetime.now().isoformat(timespec='seconds')
+    md = []
+
+    md.append('# LLM Category Report')
+    md.append('')
+    md.append(f'Generated: {ts}')
+    md.append(f'Input: {input_path}')
+    md.append(f'Total classified items: {total_processed}')
+    md.append('')
+
+    # Section 1: categories distribution
+    md.append('## 1) Suggested categories (distribution)')
+    md.append('')
+    md.append('| Category | Count | Percent |')
+    md.append('|---|---:|---:|')
+    for cat, cnt in sort_items(cat_counts):
+        pct = (cnt / total_processed) * 100 if total_processed else 0.0
+        md.append(f'| {cat} | {cnt} | {pct:.1f}% |')
+    md.append('')
+
+    # Section 2: tags by category
+    md.append('## 2) Tags by suggested category')
+    md.append('')
+    for cat, ccount in sort_items(cat_counts):
+        md.append(f'### Category: {cat} (n={ccount})')
+        md.append('')
+        if ccount == 0 or not tags_by_cat.get(cat):
+            md.append('_No tags observed for this category._')
+            md.append('')
+            continue
+        md.append('| Tag | Count | Percent within category |')
+        md.append('|---|---:|---:|')
+        for tag, tcnt in sort_items(tags_by_cat[cat]):
+            pct = (tcnt / ccount) * 100 if ccount else 0.0
+            md.append(f'| {tag} | {tcnt} | {pct:.1f}% |')
+        md.append('')
+
+    # Section 3: tag -> category distribution
+    md.append('## 3) Suggested tags with their category distribution')
+    md.append('')
+    if not cat_by_tag:
+        md.append('_No tags found across records._')
+    else:
+        tag_totals = {t: sum(cat_cnt.values()) for t, cat_cnt in cat_by_tag.items()}
+        for tag, ttot in sorted(tag_totals.items(), key=lambda kv: (-kv[1], kv[0])):
+            md.append(f'### Tag: {tag} (n={ttot})')
+            md.append('')
+            md.append('| Category | Count | Percent of tag |')
+            md.append('|---|---:|---:|')
+            for cat, cnt in sort_items(cat_by_tag[tag]):
+                pct = (cnt / ttot) * 100 if ttot else 0.0
+                md.append(f'| {cat} | {cnt} | {pct:.1f}% |')
+            md.append('')
+
+    output_path.write_text('\n'.join(md), encoding='utf-8')
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Generate LLM category/tag aggregate report from JSONL cache.')
+    ap.add_argument('-i', '--input', default='.cache/llm_category.jsonl', help='Path to llm_category.jsonl (default: .cache/llm_category.jsonl)')
+    ap.add_argument('-o', '--output', default='category_report.md', help='Path to write Markdown report (default: category_report.md)')
+    args = ap.parse_args()
+
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+
+    if not in_path.exists():
+        raise SystemExit(f"Input not found: {in_path}")
+
+    # Ensure output directory exists
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    generate_report(in_path, out_path)
+    print(f"Wrote report to: {out_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/pipelines/category_classifier.py
+++ b/src/pipelines/category_classifier.py
@@ -63,6 +63,15 @@ class CategoryClassifier(ContentProcessor):
         cache_key = self._cache_key(trimmed, allowed_slugs)
         result = self._load_from_cache(cache_key)
 
+        # Progress output (non-disruptive)
+        fname = ''
+        if isinstance(context, dict):
+            fname = (context.get('filename') or '')
+        if result is not None:
+            print(f"[LLM] cache: {fname}")
+        else:
+            print(f"[LLM] request: {fname}")
+
         if result is None:
             # Call provider
             result = self._classify_with_provider(trimmed, categories)

--- a/src/simplenote_importer.py
+++ b/src/simplenote_importer.py
@@ -5,6 +5,7 @@ Phase 2: Enhanced with editor pipeline and configuration support
 """
 
 import sys
+import os
 import argparse
 from pathlib import Path
 from typing import Optional
@@ -335,6 +336,7 @@ Examples:
     parser.add_argument('--llm-timeout', type=int, help='Timeout (seconds) for LLM requests')
     parser.add_argument('--llm-concurrency', type=int, help='Concurrency level for LLM requests')
     parser.add_argument('--llm-base-url', type=str, help='Base URL for OpenAI-compatible endpoints (e.g., Ollama)')
+    parser.add_argument('--clear-llm-cache', action='store_true', help='Delete LLM cache file before processing')
     
     parser.add_argument(
         '--config',
@@ -389,6 +391,18 @@ Examples:
         config.llm_concurrency = args.llm_concurrency
     if args.llm_base_url:
         config.llm_base_url = args.llm_base_url
+
+    # Optional: clear LLM cache before processing
+    if getattr(args, 'clear_llm_cache', False):
+        cache_path = Path(getattr(config, 'llm_cache_path', '.cache/llm_category.jsonl'))
+        try:
+            if cache_path.exists():
+                cache_path.unlink()
+                print(f"Cleared LLM cache: {cache_path}")
+            else:
+                print(f"No LLM cache to clear at: {cache_path}")
+        except Exception as e:
+            print(f"Warning: Could not clear LLM cache at {cache_path}: {e}")
     
     # Validate configuration
     if config:

--- a/tests/unit/test_category_classifier.py
+++ b/tests/unit/test_category_classifier.py
@@ -20,7 +20,7 @@ def test_category_classifier_confident_assignment(monkeypatch):
     clf = CategoryClassifier(config=cfg)
 
     def fake_provider(text, categories):
-        return _ClassificationResult(category_slug='house', confidence=0.95, reasons='home', suggestions=[])
+        return _ClassificationResult(category_slug='house', confidence=0.95, reasons='home', suggestions=[], tags=[])
 
     monkeypatch.setattr(clf, "_classify_with_provider", fake_provider)
 
@@ -39,7 +39,7 @@ def test_category_classifier_low_confidence_other_policy(monkeypatch):
     clf = CategoryClassifier(config=cfg)
 
     def fake_provider(text, categories):
-        return _ClassificationResult(category_slug='music', confidence=0.5, reasons='unsure', suggestions=['music'])
+        return _ClassificationResult(category_slug='music', confidence=0.5, reasons='unsure', suggestions=['music'], tags=[])
 
     monkeypatch.setattr(clf, "_classify_with_provider", fake_provider)
 
@@ -57,7 +57,7 @@ def test_category_classifier_suggest_policy(monkeypatch):
     clf = CategoryClassifier(config=cfg)
 
     def fake_provider(text, categories):
-        return _ClassificationResult(category_slug=None, confidence=0.4, reasons='ambiguous', suggestions=['house', 'recipes', 'gaming'])
+        return _ClassificationResult(category_slug=None, confidence=0.4, reasons='ambiguous', suggestions=['house', 'recipes', 'gaming'], tags=[])
 
     monkeypatch.setattr(clf, "_classify_with_provider", fake_provider)
 
@@ -77,7 +77,7 @@ def test_category_classifier_truncation(monkeypatch):
 
     def fake_provider(text, categories):
         captured['text'] = text
-        return _ClassificationResult(category_slug=None, confidence=0.0, reasons='', suggestions=[], undecided=True)
+        return _ClassificationResult(category_slug=None, confidence=0.0, reasons='', suggestions=[], tags=[], undecided=True)
 
     monkeypatch.setattr(clf, "_classify_with_provider", fake_provider)
 

--- a/tests/unit/test_category_classifier_extras.py
+++ b/tests/unit/test_category_classifier_extras.py
@@ -1,0 +1,129 @@
+import os
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.config import ImportConfig
+from src.pipelines.category_classifier import CategoryClassifier, _ClassificationResult
+
+
+def make_config(**overrides):
+    cfg = ImportConfig()
+    cfg.enable_llm_categorization = True
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def test_freeform_suggestions_kept(monkeypatch):
+    cfg = make_config(undecided_policy='suggest', suggestions_count=2)
+    clf = CategoryClassifier(config=cfg)
+
+    def fake_provider(text, categories):
+        return _ClassificationResult(category_slug=None, confidence=0.4, reasons='', suggestions=['work', 'finance', 'music'], tags=[])
+
+    monkeypatch.setattr(clf, "_classify_with_provider", fake_provider)
+
+    _, meta = clf.process("some text", {}, {"filename": "n.txt"})
+    assert meta.get('category') is None
+    assert meta.get('_category_suggestions') == ['work', 'finance']
+
+
+def test_llm_tags_normalization_and_cap(monkeypatch):
+    cfg = make_config(llm_suggest_tags=True, llm_tags_max_count=5)
+    cfg.llm_cache_enabled = False
+    clf = CategoryClassifier(config=cfg)
+
+    def fake_provider(text, categories):
+        tags = ["Home Improvement", "to_do", "HVAC", "SQL/DB", "Long Tag Name!!", "extra"]
+        return _ClassificationResult(category_slug=None, confidence=0.0, reasons='', suggestions=[], tags=tags)
+
+    monkeypatch.setattr(clf, "_classify_with_provider", fake_provider)
+
+    _, meta = clf.process("text", {}, {"filename": "n.txt"})
+    assert meta['llm_tags'] == ["home-improvement", "to-do", "hvac", "sql-db", "long-tag-name"]
+
+
+def test_cache_key_changes_with_prompt_version(monkeypatch):
+    cfg = make_config(llm_prompt_version="v1")
+    clf1 = CategoryClassifier(config=cfg)
+    k1 = clf1._cache_key("text", ["house", "other"])
+
+    cfg.llm_prompt_version = "v2"
+    clf2 = CategoryClassifier(config=cfg)
+    k2 = clf2._cache_key("text", ["house", "other"])
+
+    assert k1 != k2
+
+
+def test_cache_key_changes_with_template_content(tmp_path, monkeypatch):
+    # Write a custom template and ensure changing its contents affects the key
+    tfile = tmp_path / "tmpl.txt"
+    tfile.write_text("Version: {{llm_prompt_version}}\n{{text}}", encoding='utf-8')
+
+    cfg = make_config(llm_prompt_template_path=str(tfile), llm_prompt_version="v1")
+    clf1 = CategoryClassifier(config=cfg)
+    k1 = clf1._cache_key("text", ["other"]) 
+
+    # Change template
+    tfile.write_text("DIFF: {{llm_prompt_version}}\n{{text}}", encoding='utf-8')
+    clf2 = CategoryClassifier(config=cfg)
+    k2 = clf2._cache_key("text", ["other"]) 
+
+    assert k1 != k2
+
+
+def test_code_fence_stripping(monkeypatch):
+    cfg = make_config()
+    cfg.llm_cache_enabled = False
+    clf = CategoryClassifier(config=cfg)
+
+    def fake_completion(**kwargs):
+        content = """```json
+{"category_slug":"house","confidence":0.9,"reasons":"","suggestions":[],"tags":[]}
+```"""
+        return {"choices": [{"message": {"content": content}}]}
+
+    # Patch litellm.completion used inside classifier
+    monkeypatch.setattr("src.pipelines.category_classifier.llm_completion", fake_completion)
+
+    _, meta = clf.process("text", {}, {"filename": "n.txt"})
+    assert meta.get('category') == 'house'
+
+
+def test_provider_env_mapping(monkeypatch):
+    cfg = make_config(llm_api_keys={'openai': 'CUSTOM_OPENAI_KEY'})
+    cfg.llm_cache_enabled = False
+    clf = CategoryClassifier(config=cfg)
+
+    def fake_completion(**kwargs):
+        return {"choices": [{"message": {"content": json.dumps({
+            "category_slug": "other", "confidence": 0.1, "reasons": "", "suggestions": [], "tags": []
+        })}}]}
+
+    # Prepare env
+    if 'OPENAI_API_KEY' in os.environ:
+        del os.environ['OPENAI_API_KEY']
+    os.environ['CUSTOM_OPENAI_KEY'] = 'testkey'
+
+    monkeypatch.setattr("src.pipelines.category_classifier.llm_completion", fake_completion)
+
+    _, meta = clf.process("text", {}, {"filename": "n.txt"})
+    assert os.environ.get('OPENAI_API_KEY') == 'testkey'
+
+
+def test_provider_exception_fallback(monkeypatch):
+    cfg = make_config(undecided_policy='suggest')
+    cfg.llm_cache_enabled = False
+    clf = CategoryClassifier(config=cfg)
+
+    def boom(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.pipelines.category_classifier.llm_completion", boom)
+
+    _, meta = clf.process("text", {}, {"filename": "n.txt"})
+    # No crash, suggestions absent, and no category assigned under suggest policy
+    assert 'category' not in meta

--- a/tests/unit/test_config_validation_extras.py
+++ b/tests/unit/test_config_validation_extras.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from src.config import ImportConfig, ConfigManager
+
+
+def test_validate_llm_prompt_template_missing(tmp_path):
+    cfg = ImportConfig()
+    cfg.enable_llm_categorization = True
+    cfg.llm_prompt_template_path = str(tmp_path / "missing.txt")
+    warnings = ConfigManager().validate_config(cfg)
+    assert any("llm_prompt_template_path" in w for w in warnings)
+
+
+def test_validate_llm_tags_bounds():
+    cfg = ImportConfig()
+    cfg.enable_llm_categorization = True
+    cfg.llm_tags_max_count = -1
+    w = ConfigManager().validate_config(cfg)
+    assert any("llm_tags_max_count" in x for x in w)
+
+    cfg.llm_tags_max_count = 2
+    cfg.llm_tags_min_count = -1
+    w = ConfigManager().validate_config(cfg)
+    assert any("llm_tags_min_count must be >= 0" in x for x in w)
+
+    cfg.llm_tags_min_count = 3
+    cfg.llm_tags_max_count = 2
+    w = ConfigManager().validate_config(cfg)
+    assert any("llm_tags_min_count must be <= llm_tags_max_count" in x for x in w)
+
+
+def test_default_undecided_policy_is_suggest():
+    cfg = ImportConfig()
+    assert getattr(cfg, 'undecided_policy') == 'suggest'
+
+
+def test_create_sample_config_includes_new_keys(tmp_path):
+    cm = ConfigManager(config_dir=tmp_path)
+    out = tmp_path / "sample_config.yaml"
+    cm.create_sample_config(out)
+    text = out.read_text(encoding='utf-8')
+    assert 'llm_prompt_version' in text
+    assert 'llm_prompt_template_path' in text
+    assert 'llm_tags_max_count' in text
+    assert 'llm_tags_min_count' in text

--- a/tests/unit/test_simplenote_importer_cli_overrides.py
+++ b/tests/unit/test_simplenote_importer_cli_overrides.py
@@ -1,0 +1,114 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from src.simplenote_importer import main, SimpleNoteImporter
+
+
+def test_cli_overrides_new_llm_flags(monkeypatch, tmp_path, capsys):
+    notes = tmp_path / "notes"
+    notes.mkdir()
+
+    captured = {}
+
+    def fake_init(self, notes_directory, json_path, output_directory, config, file_system=None):
+        captured['config'] = config
+
+    def fake_run(self):
+        return True
+
+    monkeypatch.setattr(SimpleNoteImporter, "__init__", fake_init, raising=False)
+    monkeypatch.setattr(SimpleNoteImporter, "run", fake_run, raising=False)
+    monkeypatch.setattr("sys.exit", lambda code=0: None)
+
+    argv = [
+        "import.py", "--notes", str(notes), "--smart",
+        "--enable-llm", "--llm-provider", "openai",
+        "--llm-prompt-template", "config/prompts/default_classifier_prompt.txt",
+        "--llm-prompt-version", "vX",
+        "--llm-allow-freeform-suggestions",
+        "--llm-suggest-tags",
+        "--llm-tags-max", "7",
+        "--llm-tags-min", "1",
+        "--llm-suggestions-count", "4",
+    ]
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setattr("sys.argv", argv)
+
+    main()
+
+    cfg = captured['config']
+    assert cfg.enable_llm_categorization is True
+    assert cfg.llm_prompt_template_path.endswith("default_classifier_prompt.txt")
+    assert cfg.llm_prompt_version == "vX"
+    assert cfg.llm_allow_freeform_suggestions is True
+    assert cfg.llm_suggest_tags is True
+    assert cfg.llm_tags_max_count == 7
+    assert cfg.llm_tags_min_count == 1
+    assert cfg.suggestions_count == 4
+
+
+def test_cli_sets_default_model_for_openai(monkeypatch, tmp_path):
+    notes = tmp_path / "notes"
+    notes.mkdir()
+
+    captured = {}
+
+    def fake_init(self, notes_directory, json_path, output_directory, config, file_system=None):
+        captured['config'] = config
+
+    def fake_run(self):
+        return True
+
+    monkeypatch.setattr(SimpleNoteImporter, "__init__", fake_init, raising=False)
+    monkeypatch.setattr(SimpleNoteImporter, "run", fake_run, raising=False)
+    monkeypatch.setattr("sys.exit", lambda code=0: None)
+
+    argv = [
+        "import.py", "--notes", str(notes), "--smart",
+        "--enable-llm", "--llm-provider", "openai",
+    ]
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setattr("sys.argv", argv)
+
+    main()
+
+    cfg = captured['config']
+    assert cfg.llm_model == 'gpt-4o-mini'
+
+
+def test_cli_clear_llm_cache(monkeypatch, tmp_path, capsys):
+    notes = tmp_path / "notes"
+    notes.mkdir()
+
+    cache_dir = Path('.cache')
+    cache_dir.mkdir(exist_ok=True)
+    cache_file = cache_dir / 'llm_category.jsonl'
+    cache_file.write_text('x', encoding='utf-8')
+
+    def fake_init(self, notes_directory, json_path, output_directory, config, file_system=None):
+        pass
+
+    def fake_run(self):
+        return True
+
+    monkeypatch.setattr(SimpleNoteImporter, "__init__", fake_init, raising=False)
+    monkeypatch.setattr(SimpleNoteImporter, "run", fake_run, raising=False)
+    monkeypatch.setattr("sys.exit", lambda code=0: None)
+
+    argv = [
+        "import.py", "--notes", str(notes), "--smart",
+        "--clear-llm-cache"
+    ]
+
+    monkeypatch.setattr("sys.argv", argv)
+
+    main()
+
+    out = capsys.readouterr().out
+    assert "Cleared LLM cache" in out or "No LLM cache to clear" in out
+    # File should be removed if it existed
+    assert not cache_file.exists()


### PR DESCRIPTION
## Summary
This PR adds the following to LLM categorization:

- Keep primary category restricted to configured slugs (or 'other')
- Allow free-form suggestions when undecided_policy=suggest
- Return LLM-generated tags, normalized to kebab-case, stored in metadata.llm_tags
- Configurable prompt template with placeholders and llm_prompt_version; cache key includes prompt version and template hash
- New CLI flags to configure the above
- Docs and sample config updated; tests added

## Details
- CategoryClassifier
  - Loads a prompt template from  (fallback to default)
  - Renders placeholders: {{allowed_slugs}}, {{descriptions}}, {{suggestions_count}}, {{allow_freeform_suggestions}}, {{suggest_tags}}, {{tags_max_count}}, {{min_confidence}}, {{text}}, and {{llm_prompt_version}}
  - Parses code-fenced JSON
  - Stores free-form  under suggest policy
  - Normalizes  ->  (kebab-case), capped by 
  - Cache key now includes  and template hash

- Config
  - Add fields: , , , , , 
  - Default 
  - Validation for prompt path and tags min/max
  - Sample config updated (keeps  by default for tests)

- CLI
  - New flags: , , , , , , 
  - If LLM is enabled for OpenAI without a model, default to 

- Docs
  - docs/llm-categorization.md updated to document prompt template, versioned cache, free-form suggestions, and llm_tags behavior
  - config/sample_config_full.yaml updated with new fields and comments
  - Added default template at 

- Tests
  - New test files:
    - tests/unit/test_category_classifier_extras.py
    - tests/unit/test_config_validation_extras.py
    - tests/unit/test_simplenote_importer_cli_overrides.py
  - All tests pass locally: 264 passed

## Acceptance Criteria
- Ambiguous notes preserve free-form suggestions in 
- Notes receive exactly one primary category from allowed slugs or 'other'
- LLM tags are stored in  (kebab-case) with configurable max
- Cache invalidates when prompt version or template content changes
- Docs and sample config reflect new features

## Notes
- Provider preference default remains OpenAI; env var mapping via  supported
- No real network in tests; provider calls are mocked



## Concurrency (llm_concurrency)
- When enable_llm_categorization is true and llm_concurrency > 1, the importer performs an LLM pre-pass using a ThreadPoolExecutor with max_workers=llm_concurrency to classify notes concurrently.
- The in-pipeline CategoryClassifier is skipped in that case to avoid duplicate calls; the rest of the pipeline runs unchanged.
- Cache writes are protected by a lock to avoid JSONL interleaving/corruption during concurrent writes.
- Progress output: 'Step 3: LLM categorization pre-pass (concurrency=N)...' with periodic [LLM-PREPASS] M/T counters.
- Backward-compatible: with llm_concurrency <= 1, behavior remains serial as before.

### Usage
- YAML: llm_concurrency: 4
- CLI: --llm-concurrency 4
